### PR TITLE
fix perl version checks to use numeric comparisons

### DIFF
--- a/lib/Exporter/Tiny.pm
+++ b/lib/Exporter/Tiny.pm
@@ -9,10 +9,10 @@ our $VERSION   = '1.006002';
 our @EXPORT_OK = qw< mkopt mkopt_hash _croak _carp >;
 
 BEGIN {
-	*_HAS_NATIVE_LEXICAL_SUB = ( $] ge '5.037002' )
+	*_HAS_NATIVE_LEXICAL_SUB = ( "$]" >= 5.037002 )
 		? sub () { !!1 }
 		: sub () { !!0 };
-	*_HAS_MODULE_LEXICAL_SUB = ( $] ge '5.011002' and eval('require Lexical::Sub') )
+	*_HAS_MODULE_LEXICAL_SUB = ( "$]" >= 5.011002 and eval('require Lexical::Sub') )
 		? sub () { !!1 }
 		: sub () { !!0 };
 };
@@ -134,7 +134,7 @@ sub unimport
 sub _exporter_lexical_installer {
 	_HAS_NATIVE_LEXICAL_SUB and return sub {
 		my ( $sigilname, $sym ) = @{ $_[1] };
-		no warnings ( $] ge '5.037002' ? 'experimental::builtin' : () );
+		no warnings ( "$]" >= 5.037002 ? 'experimental::builtin' : () );
 		builtin::export_lexically( $sigilname, $sym );
 	};
 	_HAS_MODULE_LEXICAL_SUB and return sub {

--- a/meta/DYNAMIC_CONFIG.PL
+++ b/meta/DYNAMIC_CONFIG.PL
@@ -6,10 +6,10 @@
 		$prereq_type = 'requires';
 	}
 
-	if ( $] ge 5.011002 and $] lt 5.037002 ) {
+	if ( "$]" >= 5.011002 and "$]" < 5.037002 ) {
 		$meta->{prereqs}{runtime}{$prereq_type}{'Lexical::Var'} = '0.010';
 	}
 
 	# idk, this should be automatic or summint? put it in explicitly.
 	$meta->{prereqs}{runtime}{requires}{'Test::More'} = '0.47'
-		if $] lt 5.006002;
+		if "$]" < 5.006002;


### PR DESCRIPTION
`$]` should be compared as a number. Comparing it as string would mean any perl version >= 10 would fail the comparisons.

Some older perl versions had a bad floating point value for `$]`, so recalculate it from the string form.